### PR TITLE
tests: use tmp_path_factory in fixtures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ tests_require = [
     'flake8-future-import~=0.0,>=0.4.3',
     'mock~=2.0,>=2.0.0',
     'pytest-cov~=2.0,>=2.5.1',
-    'pytest~=3.0,>=3.3.0',
+    'pytest~=3.0,>=3.9.0',
 ]
 
 extras_require = {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -73,14 +73,15 @@ class Mock_RNN_Learner(RNN_Learner):
             return self._fit_result
 
 
+@pytest.fixture(scope='session')
 @patch(
     'fastai.text.RNN_Learner', Mock_RNN_Learner
 )
 @patch(
     'inspire_classifier.domain.models.RNN_Learner', Mock_RNN_Learner
 )
-@pytest.fixture(scope='session')
-def trained_pipeline(app):
+def trained_pipeline(app, tmpdir_factory):
+    app.config['CLASSIFIER_BASE_PATH'] = str(tmpdir_factory)
     create_directories()
     shutil.copy(Path(__file__).parent / 'fixtures' / 'inspire_test_data.df', path_for('dataframe'))
     train()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -80,8 +80,8 @@ class Mock_RNN_Learner(RNN_Learner):
 @patch(
     'inspire_classifier.domain.models.RNN_Learner', Mock_RNN_Learner
 )
-def trained_pipeline(app, tmpdir_factory):
-    app.config['CLASSIFIER_BASE_PATH'] = str(tmpdir_factory)
+def trained_pipeline(app, tmp_path_factory):
+    app.config['CLASSIFIER_BASE_PATH'] = tmp_path_factory
     create_directories()
     shutil.copy(Path(__file__).parent / 'fixtures' / 'inspire_test_data.df', path_for('dataframe'))
     train()

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -28,12 +28,12 @@ def test_health_check(app_client):
     assert app_client.get('/api/health').status_code == 200
 
 
-def test_classifier_accepts_only_post(app, app_client, trained_pipeline):
+def test_classifier_accepts_only_post(app_client, trained_pipeline):
     assert app_client.post('/api/classifier', data=dict(title='foo bar', abstract='foobar foobar')).status_code == 200
     assert app_client.get('/api/classifier').status_code == 405
 
 
-def test_classifier(app, app_client, trained_pipeline):
+def test_classifier(app_client, trained_pipeline):
     response = app_client.post('/api/classifier', data=dict(title='foo bar', abstract='foobar foobar'))
 
     result = json.loads(response.data)
@@ -46,10 +46,10 @@ def test_classifier(app, app_client, trained_pipeline):
                    abs_tol=1e-2)
 
 
-def test_classifier_serializes_input(app, app_client, trained_pipeline):
+def test_classifier_serializes_input(app_client, trained_pipeline):
     assert app_client.post('/api/classifier', data=dict(title='foo bar')).status_code == 422
     assert app_client.post('/api/classifier', data=dict(abstract='foo bar')).status_code == 422
 
 
-def test_classifier_accepts_extra_fields(app, app_client, trained_pipeline):
+def test_classifier_accepts_extra_fields(app_client, trained_pipeline):
     assert app_client.post('/api/classifier', data=dict(title='foo bar', abstract='foo bar', author='foo')).status_code == 200

--- a/tests/integration/test_classifier_api.py
+++ b/tests/integration/test_classifier_api.py
@@ -123,7 +123,7 @@ def test_train_and_save_classifier(trained_pipeline):
     assert path_for('trained_classifier').exists()
 
 
-def test_predict_coreness(app, trained_pipeline):
+def test_predict_coreness(trained_pipeline):
     assert path_for('data_itos').exists()
     assert path_for('trained_classifier').exists()
     output_dict = predict_coreness(title=TEST_TITLE, abstract=TEST_ABSTRACT)


### PR DESCRIPTION
Uses the tmp_path_factory fixture for using a temporary directory in tests (introduced in PyTest 3.9). Also fixes issues with using fixtures in newer versions of PyTest (>= 3.7.2). 

Signed-off-by: Salman Maqbool <salman.maqbool@cern.ch>