### PR TITLE
ml: refactor the Tokenizer for faster processing

### DIFF
--- a/inspire_classifier/domain/models.py
+++ b/inspire_classifier/domain/models.py
@@ -35,14 +35,12 @@ from fastai.text import (
     LanguageModelData,
     load_model,
     ModelData,
-    partition_by_cores,
     RNN_Learner,
     T,
     TextDataset,
     TextModel,
     to_gpu,
     to_np,
-    Tokenizer,
     save_model,
     seq2seq_reg,
     SortishSampler,
@@ -50,6 +48,7 @@ from fastai.text import (
     Variable
 )
 from functools import partial
+from inspire_classifier.utils import FastLoadTokenizer
 import numpy as np
 import pickle
 
@@ -147,6 +146,8 @@ class Classifier(object):
                                        dropouti=dropouts[0], wdrop=dropouts[1], dropoute=dropouts[2],
                                        dropouth=dropouts[3])
 
+        self.tokenizer = FastLoadTokenizer()
+
     def load_training_and_validation_data(self, training_data_ids_path, training_data_labels_path,
                                           validation_data_ids_path, validation_data_labels_path, classifier_data_dir,
                                           batch_size=10):
@@ -204,7 +205,7 @@ class Classifier(object):
 
         input_string = 'xbos xfld 1 ' + text
         texts = [input_string]
-        tokens = Tokenizer(lang='en_core_web_sm').proc_all_mp(partition_by_cores(texts), lang='en_core_web_sm')
+        tokens = self.tokenizer.proc_all(texts)
         encoded_tokens = [self.inspire_data_stoi[p] for p in tokens[0]]
         token_array = np.reshape(np.array(encoded_tokens), (-1, 1))
         token_array = Variable(torch.from_numpy(token_array))

--- a/inspire_classifier/domain/preprocessor.py
+++ b/inspire_classifier/domain/preprocessor.py
@@ -26,16 +26,14 @@
 
 
 import collections
+from fastai.text import partition_by_cores
 import html
+from inspire_classifier.utils import FastLoadTokenizer
 import numpy as np
 import pandas as pd
 import pickle
 import re
 import sklearn
-from fastai.text import (
-    Tokenizer,
-    partition_by_cores
-)
 
 
 BOS = 'xbos'  # beginning-of-sentence tag
@@ -164,7 +162,7 @@ def get_texts(df):
     texts = f'\n{BOS} {FLD} 1 ' + df[1].astype(str)
     texts = list(texts.apply(fixup).values)
 
-    tokens = Tokenizer(lang='en_core_web_sm').proc_all_mp(partition_by_cores(texts), lang='en_core_web_sm')
+    tokens = FastLoadTokenizer().proc_all_mp(partition_by_cores(texts))
     return tokens, list(labels)
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@
 from __future__ import absolute_import, division, print_function
 
 from setuptools import find_packages, setup
-from setuptools.command.install import install
 
 
 url = 'https://github.com/inspirehep/inspire-classifier'
@@ -43,7 +42,6 @@ install_requires = [
     'marshmallow~=3.0.0b13,>=3.0.0b13',
     'numpy~=1.15,>=1.15.0',
     'spacy~=2.0,>=2.0.0',
-    'en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz',
     'torchtext==0.2.3'
 ]
 

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from fastai.text import partition_by_cores
+from inspire_classifier.utils import FastLoadTokenizer
+
+TEST_TEXT = ['Pre-images of extreme points of the numerical range, and applications']
+
+
+def test_fast_load_tokenizer_proc_all():
+    tokenizer = FastLoadTokenizer()
+    expected = [['pre', '-', 'images', 'of', 'extreme', 'points', 'of', 'the', 'numerical', 'range', ',', 'and',
+                 'applications']]
+    result = tokenizer.proc_all(TEST_TEXT)
+    assert result == expected
+
+
+def test_fast_load_tokenizer_proc_all_mp():
+    tokenizer = FastLoadTokenizer()
+    expected = [['pre', '-', 'images', 'of', 'extreme', 'points', 'of', 'the', 'numerical', 'range', ',', 'and',
+                 'applications']]
+    result = tokenizer.proc_all_mp(partition_by_cores(TEST_TEXT))
+    assert result == expected


### PR DESCRIPTION
The FastAI Tokenizer class loads all the pipeline components of the spacy model which significantly increases loading time, especially when doing inference on CPU. This class inherits from the FastAI Tokenizer and is refactored to avoid redundant loading of the classifier. Additionally, we no longer require downloading spacy language models.

Signed-off-by: Salman Maqbool salman.maqbool@cern.ch