### PR TITLE
tests: fix tmp_path_factory

### DIFF
--- a/inspire_classifier/utils.py
+++ b/inspire_classifier/utils.py
@@ -35,7 +35,7 @@ from spacy.symbols import ORTH
 
 
 def path_for(name):
-    base_path = Path(current_app.config.get('CLASSIFER_BASE_PATH') or current_app.instance_path)
+    base_path = Path(current_app.config.get('CLASSIFIER_BASE_PATH') or current_app.instance_path)
     config_key = f'CLASSIFIER_{name}_PATH'.upper()
 
     return base_path / current_app.config[config_key]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -81,7 +81,7 @@ class Mock_RNN_Learner(RNN_Learner):
     'inspire_classifier.domain.models.RNN_Learner', Mock_RNN_Learner
 )
 def trained_pipeline(app, tmp_path_factory):
-    app.config['CLASSIFIER_BASE_PATH'] = tmp_path_factory
+    app.config['CLASSIFIER_BASE_PATH'] = tmp_path_factory.getbasetemp()
     create_directories()
     shutil.copy(Path(__file__).parent / 'fixtures' / 'inspire_test_data.df', path_for('dataframe'))
     train()


### PR DESCRIPTION
Due to a typo in utils, the tmp_path_factory was never used. This commit fixes that.

Signed-off-by: Salman Maqbool salman.maqbool@cern.ch